### PR TITLE
Rules Update for ATF

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -9,7 +9,8 @@ parser: "@typescript-eslint/parser"
 plugins: [ '@typescript-eslint', 'eslint-plugin-node' ]
 
 parserOptions:
-  ecmaVersion: 2020
+  emcaVersion: 2020
+  sourceType: module
 
 rules:
   indent: [ "error", "tab" ]

--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -4,7 +4,7 @@
   "attr-value-double-quotes": true,
   "attr-value-not-empty": false,
   "attr-no-duplication": true,
-  "doctype-first": true,
+  "doctype-first": false,
   "tag-pair": true,
   "tag-self-close": false,
   "spec-char-escape": true,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -5,6 +5,7 @@
     "number-leading-zero": null,
     "block-no-empty": null,
     "color-hex-case": null,
-    "color-hex-length": null
+    "color-hex-length": null,
+	"declaration-empty-line-before": null
   }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -6,6 +6,6 @@
     "block-no-empty": null,
     "color-hex-case": null,
     "color-hex-length": null,
-	"declaration-empty-line-before": null
+    "declaration-empty-line-before": null
   }
 }


### PR DESCRIPTION
Update rules:

remove doctype-first because it complains about doctypes on html files which are meant as shadow-dom templates
ideally, this would only warn on files that contain an `<html>` tag I think.

fix typescript linting by including sourceType: module in the eslint config

remove the declaration-empty-line-before CSS rule, because I like to group multiple related rules by using spaces, i.e.:
```css
button {
  padding-left: 10px;
  padding-right: 10px;

  font-size: 1.2em;
  color: black;
}
```
