### PR TITLE
Disable eslint Indent Linting

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -13,4 +13,6 @@ parserOptions:
   sourceType: module
 
 rules:
-  indent: [ "error", "tab" ]
+  # disabled for now, since there's no option for double-indent on continued line
+  # indent: [ "error", "tab" ]
+  indent: off


### PR DESCRIPTION
Our usual code style asks for double indent on continued lines, for example:

```js
if (something &&
    something_else) {
  doThing();
}

aPromise()
    .then(result => console.log(result));
{
  inBlock();
}
```

This used to fail eslint because of the double indents, and I couldn't figure out a way to configure that. So here we are.