### PR TITLE
Update repos script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,6 @@ Make sure you use https and not ssh
 
 
 ## Updating Bragi Submodule
-After changing the submodule commit pointer for Bragi then the linter-workflow.yml file may also be automatically updated.  Make sure you commit both the submodule and the workflow file when that happens.
-Alternatively you can run the `update_all_inside_parent.sh` script to automatically create update branches of the bragi submodule for all the projects that this linter has been added to.  This is for projects that are sibling to your checked out Bragi repo).
+Manually: After changing the submodule commit pointer for Bragi then the linter-workflow.yml file may also be automatically updated.  Make sure you commit both the submodule and the workflow file when that happens.
+Automatically: Run the `update_all_inside_parent.sh` script to automatically create update branches of the bragi submodule for all the projects that this linter has been added to.  This will run on supported projects that are sibling to your checked out Bragi repository.
+- Warning: any changes in your working tree or index will be temporarily stashed which means interupting the script may result in a repo being left with your code being left in a stashed state.  Run `git stash list` in the problematic repository to view the stashes if that happens.

--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ Make sure you use https and not ssh
 
 ## Updating Bragi Submodule
 After changing the submodule commit pointer for Bragi then the linter-workflow.yml file may also be automatically updated.  Make sure you commit both the submodule and the workflow file when that happens.
+Alternatively you can run the `update_all_inside_parent.sh` script to automatically create update branches of the bragi submodule for all the projects that this linter has been added to.  This is for projects that are sibling to your checked out Bragi repo).

--- a/scripts/run-local-lint.sh
+++ b/scripts/run-local-lint.sh
@@ -8,8 +8,9 @@ if [ "$diff_files" != "$diff_all" ]; then
     exit 1;
 fi;
 
-git stash push --keep-index -m "working_tree" > /dev/null;
-git stash push --keep-index -m "index" > /dev/null;
+now=$(date);
+git stash push --keep-index -m "working_tree_$now" > /dev/null;
+git stash push --keep-index -m "index_$now" > /dev/null;
 
 # OSX and GNU xargs behave different by default
 xargs_command="xargs";
@@ -71,18 +72,18 @@ lint yml 'yamllint -c .github/linters/.yaml-lint.yml' .
 # restore both the working tree and index
 git reset > /dev/null;
 git checkout .;
-working_tree_stash_num=$(git stash list | grep "working_tree" | sed 's/stash@{\(.*\)}.*/\1/')
+working_tree_stash_num=$(git stash list | grep "working_tree_$now" | sed 's/stash@{\(.*\)}.*/\1/')
 if [ -n "$working_tree_stash_num" ]; then
     git checkout "stash@{$working_tree_stash_num}" .;
     git stash drop "stash@{$working_tree_stash_num}" > /dev/null;
 fi;
 git reset > /dev/null;
-index_stash_num=$(git stash list | grep "index" | sed 's/stash@{\(.*\)}.*/\1/')
+index_stash_num=$(git stash list | grep "index_$now" | sed 's/stash@{\(.*\)}.*/\1/')
 if [ -n "$index_stash_num" ]; then
     git reset "stash@{$index_stash_num}" > /dev/null; 
     git stash drop "stash@{$index_stash_num}" > /dev/null;
+    git reset --soft HEAD~1;
 fi;
-git reset --soft HEAD~1;
 
 # Automatically fix the files in our working tree
 # no automatic java fix

--- a/scripts/update_all_inside_parent.sh
+++ b/scripts/update_all_inside_parent.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+git_dir="$1";
+auto_clone=true;
+
+if [ "$git_dir" == "" ]; then
+    echo "Missing argument 1: Path to your parent git folder.";
+    exit 1;
+fi;
+
+original_pwd=$(pwd);
+update_script="../Bragi/scripts/update_inside_parent.sh";
+
+update () {
+    repo_branch="$1";
+    bragi_branch="$2";
+    repos="$3";
+    for repo in $repos; do
+        (
+            if $auto_clone; then
+                if ! cd "$git_dir/$repo" > /dev/null 2> /dev/null; then
+                    cd "$git_dir" || exit 1;
+                    git clone "git@github.com:BigVikingGames/$repo.git";
+                fi;
+            fi;
+
+            if cd "$git_dir/$repo" > /dev/null 2> /dev/null; then
+                echo "Updating branch for $repo.";
+                $update_script "$repo_branch" "$bragi_branch" > /dev/null 2> /dev/null;
+                changed=$(git diff "origin/$repo_branch" "origin/PTR-linter-$repo_branch" --name-only 2> /dev/null);
+                unexpected_changed=$(echo "$changed" | grep -vwE "(\.github/linters|\.github/workflows/linter-workflow.yml|\.gitmodules)");
+                if [ "$unexpected_changes" == "" ]; then
+                    if [ "$changed" != "" ]; then
+                        echo "- Status: Needs PR";
+                    fi;
+                else
+                    echo "- Status: Accidentally committed incorrect files.  Need manual fix";
+                fi;
+            else
+                echo "Skipping $repo since it could not be found inside $git_dir."
+            fi;
+        )
+    done;
+}
+
+update master master "
+    gjoll-elli gjoll-relay-server gjoll-app-stream Tarnhelm swftool bvg-unity-commons norns-ptr environment-config-ptr
+    Bragi Nidavellir tools-analytics PTR-Tools-Server BAM BAM-Unity WorldsElectron VirtualVikoins
+";
+#YoWorld Fish-World Fish-World-Tools Kella Yggdrasil

--- a/scripts/update_all_inside_parent.sh
+++ b/scripts/update_all_inside_parent.sh
@@ -1,14 +1,36 @@
 #!/bin/sh
-git_dir="$1";
-auto_clone=true;
+git_dir="";
+auto_clone='false';
+
+print_usage() {
+    printf "Usage:  -g {git_dir} to specify the path to your parent git folder.
+        -c to specify that missing repos are to be automatically cloned (default: false)";
+}
+
+while getopts 'cg:' flag; do
+    case "${flag}" in
+        c) auto_clone='true' ;;
+        g) git_dir="${OPTARG}" ;;
+        *) print_usage
+            exit 1 ;;
+    esac
+done
 
 if [ "$git_dir" == "" ]; then
-    echo "Missing argument 1: Path to your parent git folder.";
+    print_usage;
     exit 1;
 fi;
 
-original_pwd=$(pwd);
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+ORANGE='\033[0;33m'
+YWLLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
 update_script="../Bragi/scripts/update_inside_parent.sh";
+
+cd "$git_dir" || exit 1;
 
 update () {
     repo_branch="$1";
@@ -16,34 +38,39 @@ update () {
     repos="$3";
     for repo in $repos; do
         (
-            if $auto_clone; then
-                if ! cd "$git_dir/$repo" > /dev/null 2> /dev/null; then
-                    cd "$git_dir" || exit 1;
-                    git clone "git@github.com:BigVikingGames/$repo.git";
+            echo "Updating branch PTR-linter-$repo_branch for $repo.";
+            if [ ! -d "$repo" ]; then
+                if "$auto_clone"; then
+                    echo "- Status: Cloning missing repo.";
+                    git clone "git@github.com:BigVikingGames/$repo.git" > /dev/null;
+                else
+                    echo "- Status:$YELLOW Missing repo.  Use -c to automatically clone it.$NC";
                 fi;
             fi;
 
-            if cd "$git_dir/$repo" > /dev/null 2> /dev/null; then
-                echo "Updating branch for $repo.";
+            if cd "$repo" > /dev/null 2> /dev/null; then
                 $update_script "$repo_branch" "$bragi_branch" > /dev/null 2> /dev/null;
                 changed=$(git diff "origin/$repo_branch" "origin/PTR-linter-$repo_branch" --name-only 2> /dev/null);
                 unexpected_changed=$(echo "$changed" | grep -vwE "(\.github/linters|\.github/workflows/linter-workflow.yml|\.gitmodules)");
                 if [ "$unexpected_changes" == "" ]; then
                     if [ "$changed" != "" ]; then
-                        echo "- Status: Needs PR";
+                        echo "- Status:$ORANGE Needs PR creates and/or merged.$NC";
+                    else
+                        echo "- Status:$GREEN Already up to date.$NC";
                     fi;
                 else
-                    echo "- Status: Accidentally committed incorrect files.  Need manual fix";
+                    echo "- Status:$RED Accidentally committed incorrect files.  Need manual fix!$NC";
                 fi;
-            else
-                echo "Skipping $repo since it could not be found inside $git_dir."
+                cd ..;
             fi;
         )
     done;
 }
 
-update master master "
-    gjoll-elli gjoll-relay-server gjoll-app-stream Tarnhelm swftool bvg-unity-commons norns-ptr environment-config-ptr
-    Bragi Nidavellir tools-analytics PTR-Tools-Server BAM BAM-Unity WorldsElectron VirtualVikoins
-";
+#update parent_base_branch bragi_branch
+update master master "BAM
+BAM-Unity";
+#    gjoll-elli gjoll-relay-server gjoll-app-stream Tarnhelm swftool bvg-unity-commons norns-ptr environment-config-ptr
+#    Bragi Nidavellir tools-analytics PTR-Tools-Server BAM BAM-Unity WorldsElectron VirtualVikoins
+#";
 #YoWorld Fish-World Fish-World-Tools Kella Yggdrasil

--- a/scripts/update_all_inside_parent.sh
+++ b/scripts/update_all_inside_parent.sh
@@ -28,9 +28,11 @@ NC='\033[0m' # No Color
 
 update_script="../Bragi/scripts/update_inside_parent.sh";
 
+# navigate to your git directory that contains all your git repos
 cd "$(dirname "$0")" || exit 1;
 cd ../.. || exit 1;
 
+# creates branches for a set of repositories that makes changes to update to the specified bragi branch for the specified repo branch
 update () {
     repo_branch="$1";
     bragi_branch="$2";
@@ -58,7 +60,7 @@ update () {
                 unexpected_changed=$(echo "$changed" | grep -vwE "(\.github/linters|\.github/workflows/linter-workflow.yml|\.gitmodules)");
                 if [ "$unexpected_changes" == "" ]; then
                     if [ "$changed" != "" ]; then
-                        echo "- Status:$ORANGE Needs PR created and/or merged.$NC";
+                        echo "- Status:$ORANGE Needs PR created and/or merged.$NC https://github.com/BigVikingGames/$repo/compare/PTR-linter-$repo_branch";
                     else
                         echo "- Status:$GREEN Already up to date.$NC";
                     fi;
@@ -80,7 +82,7 @@ update master master "
     Flamingo pryor-prototype
     Fish-World Fish-World-Tools norns-fw environment-config-fishworld
     yoworld-cli YoWoMo YoWorld-Forums norns-yw environment-config-yoworld
-    Norns tyr Kella bvg-commons Yggdrasil Jormungand
+    Norns tyr Kellaa bvg-commons Yggdrasil Jormungand
 ";
 update unstable master "YoWorld";
 update "norns_2.0" master "Norns";

--- a/scripts/update_all_inside_parent.sh
+++ b/scripts/update_all_inside_parent.sh
@@ -1,25 +1,23 @@
 #!/bin/sh
 git_dir="";
 auto_clone='false';
+verbose='false';
+filter='.*';
 
 print_usage() {
-    printf "Usage:  -g {git_dir} to specify the path to your parent git folder.
-        -c to specify that missing repos are to be automatically cloned (default: false)";
+    printf "Usage:  -c to specify that missing repos are to be automatically cloned (default: false)
+        -v verbose (default: false)
+        -f {filter_expression} regular expression for which repositories to update (default: .*)";
 }
 
-while getopts 'cg:' flag; do
+while getopts 'cvf:' flag; do
     case "${flag}" in
         c) auto_clone='true' ;;
-        g) git_dir="${OPTARG}" ;;
+        f) filter="${OPTARG}" ;;
         *) print_usage
             exit 1 ;;
     esac
 done
-
-if [ "$git_dir" == "" ]; then
-    print_usage;
-    exit 1;
-fi;
 
 
 RED='\033[0;31m'
@@ -30,13 +28,15 @@ NC='\033[0m' # No Color
 
 update_script="../Bragi/scripts/update_inside_parent.sh";
 
-cd "$git_dir" || exit 1;
+cd "$(dirname "$0")" || exit 1;
+cd ../.. || exit 1;
 
 update () {
     repo_branch="$1";
     bragi_branch="$2";
-    repos="$3";
-    for repo in $repos; do
+    all_repos="$3";
+    filtered_repos=$(echo "$3" | xargs -n 1 | grep "$filter");
+    for repo in $filtered_repos; do
         (
             echo "Updating branch PTR-linter-$repo_branch for $repo.";
             if [ ! -d "$repo" ]; then
@@ -67,7 +67,7 @@ update () {
     done;
 }
 
-#update parent_base_branch bragi_branch
+#update parent_base_branch bragi_branch repo_list
 update master master "
     gjoll-elli gjoll-relay-server gjoll-app-stream
     Tarnhelm swftool bvg-unity-commons BAM BAM-Unity hermod

--- a/scripts/update_all_inside_parent.sh
+++ b/scripts/update_all_inside_parent.sh
@@ -54,7 +54,7 @@ update () {
                 unexpected_changed=$(echo "$changed" | grep -vwE "(\.github/linters|\.github/workflows/linter-workflow.yml|\.gitmodules)");
                 if [ "$unexpected_changes" == "" ]; then
                     if [ "$changed" != "" ]; then
-                        echo "- Status:$ORANGE Needs PR creates and/or merged.$NC";
+                        echo "- Status:$ORANGE Needs PR created and/or merged.$NC";
                     else
                         echo "- Status:$GREEN Already up to date.$NC";
                     fi;
@@ -68,9 +68,15 @@ update () {
 }
 
 #update parent_base_branch bragi_branch
-update master master "BAM
-BAM-Unity";
-#    gjoll-elli gjoll-relay-server gjoll-app-stream Tarnhelm swftool bvg-unity-commons norns-ptr environment-config-ptr
-#    Bragi Nidavellir tools-analytics PTR-Tools-Server BAM BAM-Unity WorldsElectron VirtualVikoins
-#";
-#YoWorld Fish-World Fish-World-Tools Kella Yggdrasil
+update master master "
+    gjoll-elli gjoll-relay-server gjoll-app-stream
+    Tarnhelm swftool bvg-unity-commons BAM BAM-Unity hermod
+    Bragi Nidavellir tools-analytics PTR-Tools-Server WorldsElectron VirtualVikoins Task-Scheduler
+    devops Jenkins embla norns-ptr environment-config-ptr
+    Flamingo pryor-prototype
+    Fish-World Fish-World-Tools norns-fw environment-config-fishworld
+    yoworld-cli YoWoMo YoWorld-Forums norns-yw environment-config-yoworld
+    Norns tyr Kella bvg-commons Yggdrasil Jormungand
+";
+update unstable master "YoWorld";
+update "norns_2.0" master "Norns";

--- a/scripts/update_all_inside_parent.sh
+++ b/scripts/update_all_inside_parent.sh
@@ -13,12 +13,12 @@ print_usage() {
 while getopts 'cvf:' flag; do
     case "${flag}" in
         c) auto_clone='true' ;;
+        v) verbose='true' ;;
         f) filter="${OPTARG}" ;;
         *) print_usage
             exit 1 ;;
     esac
 done
-
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -49,7 +49,11 @@ update () {
             fi;
 
             if cd "$repo" > /dev/null 2> /dev/null; then
-                $update_script "$repo_branch" "$bragi_branch" > /dev/null 2> /dev/null;
+                if "$verbose"; then
+                    $update_script "$repo_branch" "$bragi_branch";
+                else
+                    $update_script "$repo_branch" "$bragi_branch" > /dev/null 2> /dev/null;
+                fi;
                 changed=$(git diff "origin/$repo_branch" "origin/PTR-linter-$repo_branch" --name-only 2> /dev/null);
                 unexpected_changed=$(echo "$changed" | grep -vwE "(\.github/linters|\.github/workflows/linter-workflow.yml|\.gitmodules)");
                 if [ "$unexpected_changes" == "" ]; then

--- a/scripts/update_all_inside_parent.sh
+++ b/scripts/update_all_inside_parent.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-git_dir="";
 auto_clone='false';
 verbose='false';
 filter='.*';
@@ -23,7 +22,7 @@ done
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 ORANGE='\033[0;33m'
-YWLLOW='\033[1;33m'
+YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 update_script="../Bragi/scripts/update_inside_parent.sh";
@@ -37,7 +36,7 @@ update () {
     repo_branch="$1";
     bragi_branch="$2";
     all_repos="$3";
-    filtered_repos=$(echo "$3" | xargs -n 1 | grep "$filter");
+    filtered_repos=$(echo "$all_repos" | xargs -n 1 | grep "$filter");
     for repo in $filtered_repos; do
         (
             echo "Updating branch PTR-linter-$repo_branch for $repo.";
@@ -57,8 +56,8 @@ update () {
                     $update_script "$repo_branch" "$bragi_branch" > /dev/null 2> /dev/null;
                 fi;
                 changed=$(git diff "origin/$repo_branch" "origin/PTR-linter-$repo_branch" --name-only 2> /dev/null);
-                unexpected_changed=$(echo "$changed" | grep -vwE "(\.github/linters|\.github/workflows/linter-workflow.yml|\.gitmodules)");
-                if [ "$unexpected_changes" == "" ]; then
+                unexpected_changes=$(echo "$changed" | grep -vwE "(\.github/linters|\.github/workflows/linter-workflow.yml|\.gitmodules)");
+                if [ "$unexpected_changes" = "" ]; then
                     if [ "$changed" != "" ]; then
                         echo "- Status:$ORANGE Needs PR created and/or merged.$NC https://github.com/BigVikingGames/$repo/compare/PTR-linter-$repo_branch";
                     else

--- a/scripts/update_inside_parent.sh
+++ b/scripts/update_inside_parent.sh
@@ -15,6 +15,7 @@
 
     linter_branch_prefix="PTR-linter-";
 
+    # store old the existing branch, index and working tree
     diff_files=$(git diff --name-only --ignore-submodules);
     diff_all=$(git diff --name-only --ignore-submodules=dirty);
     if [ "$diff_files" != "$diff_all" ]; then
@@ -27,13 +28,12 @@
     git reset > /dev/null;
     git checkout .;
     git clean -f -d;
-
     old_branch=$(git branch --show-current);
     git checkout $default_branch;
-    git config pull.rebase false;
-    git fetch;
-    #git pull;
 
+    # create or update the branch with any new Bragi updates
+    git fetch;
+    git config pull.rebase false;
     linter_branch="$linter_branch_prefix$default_branch";
     git checkout "$linter_branch" --;
     git checkout -b "$linter_branch";
@@ -42,6 +42,7 @@
     if [ "$check_branch" == "$linter_branch" ]; then
         untracked_files=$(git ls-files --others --exclude-standard | grep .github/linters);
         if [ "$untracked_files" != "" ]; then
+            # need to manually remove this since the bragi submodule cannot be stashed which may leads to conflicts later when merging in master.
             rm -rf .github/linters;
         fi;
         git checkout .;
@@ -66,6 +67,8 @@
             git push --set-upstream origin "$linter_branch";
         fi;
     fi;
+
+    # restore your old original branch, index and working tree
     git reset > /dev/null;
     git checkout .;
     git checkout $old_branch;

--- a/scripts/update_inside_parent.sh
+++ b/scripts/update_inside_parent.sh
@@ -1,87 +1,85 @@
 #!/bin/sh
-(
-    default_branch="$1";
-    submodule_branch="master";#"$2";
+default_branch="$1";
+submodule_branch="master";#"$2";
 
-    if [ "$default_branch" == "" ]; then
-        echo "Missing argument 1: Default branch name for this repo.";
-        exit 1;
+if [ "$default_branch" == "" ]; then
+    echo "Missing argument 1: Default branch name for this repo.";
+    exit 1;
+fi;
+
+if ! git status; then
+    echo "Must be called from within a git repo.";
+    exit 1;
+fi;
+
+linter_branch_prefix="PTR-linter-";
+
+# store old the existing branch, index and working tree
+diff_files=$(git diff --name-only --ignore-submodules);
+diff_all=$(git diff --name-only --ignore-submodules=dirty);
+if [ "$diff_files" != "$diff_all" ]; then
+    echo "All submodules must be be added to the index before commiting when local linting is enabled."
+    exit 1;
+fi;
+now=$(date);
+git stash push --all --keep-index -m "working_tree_$now" > /dev/null;
+git stash push --all --keep-index -m "index_$now" > /dev/null;
+git reset > /dev/null;
+git checkout .;
+git clean -f -d;
+old_branch=$(git branch --show-current);
+git checkout $default_branch;
+
+# create or update the branch with any new Bragi updates
+git fetch;
+git config pull.rebase false;
+linter_branch="$linter_branch_prefix$default_branch";
+git checkout "$linter_branch" --;
+git checkout -b "$linter_branch";
+git checkout "$linter_branch" --;
+check_branch=$(git branch --show-current);
+if [ "$check_branch" == "$linter_branch" ]; then
+    untracked_files=$(git ls-files --others --exclude-standard | grep .github/linters);
+    if [ "$untracked_files" != "" ]; then
+        # need to manually remove this since the bragi submodule cannot be stashed which may leads to conflicts later when merging in master.
+        rm -rf .github/linters;
     fi;
-
-    if ! git status; then
-        echo "Must be called from within a git repo.";
-        exit 1;
-    fi;
-
-    linter_branch_prefix="PTR-linter-";
-
-    # store old the existing branch, index and working tree
-    diff_files=$(git diff --name-only --ignore-submodules);
-    diff_all=$(git diff --name-only --ignore-submodules=dirty);
-    if [ "$diff_files" != "$diff_all" ]; then
-        echo "All submodules must be be added to the index before commiting when local linting is enabled."
-        exit 1;
-    fi;
-    now=$(date);
-    git stash push --all --keep-index -m "working_tree_$now" > /dev/null;
-    git stash push --all --keep-index -m "index_$now" > /dev/null;
-    git reset > /dev/null;
     git checkout .;
-    git clean -f -d;
-    old_branch=$(git branch --show-current);
-    git checkout $default_branch;
+    git pull;
+    if git merge "origin/$default_branch" -m "merge from origin/$default_branch"; then
+        git add .github/linters;
+        git commit -n -m "merge from $default_branch";
+        git submodule add --force https://github.com/BigVikingGames/Bragi.git .github/linters;
+        git submodule update --init .github/linters;
+        (
+            cd .github/linters;
+            git fetch;
+            git checkout "$submodule_branch";
+            git config pull.rebase false;
+            git pull;
+            cd ../..;
+        )
+        .github/linters/scripts/setup-all.sh;
+        .github/linters/scripts/setup-local-lint.sh;
+        git add .github/linters .github/workflows/linter-workflow.yml;
+        git commit -n -m "update the bragi linter submodule";
+        git push --set-upstream origin "$linter_branch";
+    fi;
+fi;
 
-    # create or update the branch with any new Bragi updates
-    git fetch;
-    git config pull.rebase false;
-    linter_branch="$linter_branch_prefix$default_branch";
-    git checkout "$linter_branch" --;
-    git checkout -b "$linter_branch";
-    git checkout "$linter_branch" --;
-    check_branch=$(git branch --show-current);
-    if [ "$check_branch" == "$linter_branch" ]; then
-        untracked_files=$(git ls-files --others --exclude-standard | grep .github/linters);
-        if [ "$untracked_files" != "" ]; then
-            # need to manually remove this since the bragi submodule cannot be stashed which may leads to conflicts later when merging in master.
-            rm -rf .github/linters;
-        fi;
-        git checkout .;
-        git pull;
-        if git merge "origin/$default_branch" -m "merge from origin/$default_branch"; then
-            git add .github/linters;
-            git commit -m "merge from $default_branch";
-            git submodule add --force https://github.com/BigVikingGames/Bragi.git .github/linters;
-            git submodule update --init .github/linters;
-            (
-                cd .github/linters;
-                git fetch;
-                git checkout "$submodule_branch";
-                git config pull.rebase false;
-                git pull;
-                cd ../..;
-            )
-            .github/linters/scripts/setup-all.sh;
-            .github/linters/scripts/setup-local-lint.sh;
-            git add .github/linters .github/workflows/linter-workflow.yml;
-            git commit -n -m "update the bragi linter submodule";
-            git push --set-upstream origin "$linter_branch";
-        fi;
-    fi;
-
-    # restore your old original branch, index and working tree
-    git reset > /dev/null;
-    git checkout .;
-    git checkout $old_branch;
-    working_tree_stash_num=$(git stash list | grep "working_tree_$now" | sed 's/stash@{\(.*\)}.*/\1/')
-    if [ -n "$working_tree_stash_num" ]; then
-        git checkout "stash@{$working_tree_stash_num}" .;
-        git stash drop "stash@{$working_tree_stash_num}" > /dev/null;
-    fi;
-    git reset > /dev/null;
-    index_stash_num=$(git stash list | grep "index_$now" | sed 's/stash@{\(.*\)}.*/\1/')
-    if [ -n "$index_stash_num" ]; then
-        git reset "stash@{$index_stash_num}" > /dev/null; 
-        git stash drop "stash@{$index_stash_num}" > /dev/null;
-        git reset --soft HEAD~1;
-    fi;
-)
+# restore your old original branch, index and working tree
+git reset > /dev/null;
+git checkout .;
+git checkout $old_branch;
+working_tree_stash_num=$(git stash list | grep "working_tree_$now" | sed 's/stash@{\(.*\)}.*/\1/')
+if [ -n "$working_tree_stash_num" ]; then
+    git checkout "stash@{$working_tree_stash_num}" .;
+    git stash drop "stash@{$working_tree_stash_num}" > /dev/null;
+fi;
+git reset > /dev/null;
+index_stash_num=$(git stash list | grep "index_$now" | sed 's/stash@{\(.*\)}.*/\1/')
+if [ -n "$index_stash_num" ]; then
+    git reset "stash@{$index_stash_num}" > /dev/null; 
+    git stash drop "stash@{$index_stash_num}" > /dev/null;
+    git reset --soft HEAD~1;
+fi;

--- a/scripts/update_inside_parent.sh
+++ b/scripts/update_inside_parent.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+(
+    default_branch="$1";
+    submodule_branch="master";#"$2";
+
+    if [ "$default_branch" == "" ]; then
+        echo "Missing argument 1: Default branch name for this repo.";
+        exit 1;
+    fi;
+
+    if ! git status; then
+        echo "Must be called from within a git repo.";
+        exit 1;
+    fi;
+
+    linter_branch_prefix="PTR-linter-";
+
+    diff_files=$(git diff --name-only --ignore-submodules);
+    diff_all=$(git diff --name-only --ignore-submodules=dirty);
+    if [ "$diff_files" != "$diff_all" ]; then
+        echo "All submodules must be be added to the index before commiting when local linting is enabled."
+        exit 1;
+    fi;
+    now=$(date);
+    git stash push --all --keep-index -m "working_tree_$now" > /dev/null;
+    git stash push --all --keep-index -m "index_$now" > /dev/null;
+    git reset > /dev/null;
+    git checkout .;
+    git clean -f -d;
+
+    old_branch=$(git branch --show-current);
+    git checkout $default_branch;
+    git config pull.rebase false;
+    git fetch;
+    #git pull;
+
+    linter_branch="$linter_branch_prefix$default_branch";
+    git checkout "$linter_branch" --;
+    git checkout -b "$linter_branch";
+    git checkout "$linter_branch" --;
+    check_branch=$(git branch --show-current);
+    if [ "$untracked_linter" == "$linter_branch" ]; then
+        untracked_files=$(git ls-files --others --exclude-standard | grep .github/linters);
+        if [ "$untracked_linter" != "" ]; then
+            rm -rf .github/linters;
+        fi;
+        git checkout .;
+        git pull;
+        if git merge "origin/$default_branch" -m "merge from origin/$default_branch"; then
+            git add .github/linters;
+            git commit -m "merge from $default_branch";
+            git submodule add --force https://github.com/BigVikingGames/Bragi.git .github/linters;
+            git submodule update --init .github/linters;
+            (
+                cd .github/linters;
+                git fetch;
+                git checkout "$submodule_branch";
+                git config pull.rebase false;
+                git pull;
+                cd ../..;
+            )
+            .github/linters/scripts/setup-all.sh;
+            .github/linters/scripts/setup-local-lint.sh;
+            git add .github/linters .github/workflows/linter-workflow.yml;
+            git commit -n -m "update the bragi linter submodule";
+            git push --set-upstream origin "$linter_branch";
+        fi;
+    fi;
+    git reset > /dev/null;
+    git checkout .;
+    git checkout $old_branch;
+    working_tree_stash_num=$(git stash list | grep "working_tree_$now" | sed 's/stash@{\(.*\)}.*/\1/')
+    if [ -n "$working_tree_stash_num" ]; then
+        git checkout "stash@{$working_tree_stash_num}" .;
+        git stash drop "stash@{$working_tree_stash_num}" > /dev/null;
+    fi;
+    git reset > /dev/null;
+    index_stash_num=$(git stash list | grep "index_$now" | sed 's/stash@{\(.*\)}.*/\1/')
+    if [ -n "$index_stash_num" ]; then
+        git reset "stash@{$index_stash_num}" > /dev/null; 
+        git stash drop "stash@{$index_stash_num}" > /dev/null;
+        git reset --soft HEAD~1;
+    fi;
+)

--- a/scripts/update_inside_parent.sh
+++ b/scripts/update_inside_parent.sh
@@ -2,7 +2,7 @@
 default_branch="$1";
 submodule_branch="master";#"$2";
 
-if [ "$default_branch" == "" ]; then
+if [ "$default_branch" = "" ]; then
     echo "Missing argument 1: Default branch name for this repo.";
     exit 1;
 fi;
@@ -28,7 +28,7 @@ git reset > /dev/null;
 git checkout .;
 git clean -f -d;
 old_branch=$(git branch --show-current);
-git checkout $default_branch;
+git checkout "$default_branch";
 
 # create or update the branch with any new Bragi updates
 git fetch;
@@ -38,7 +38,7 @@ git checkout "$linter_branch" --;
 git checkout -b "$linter_branch";
 git checkout "$linter_branch" --;
 check_branch=$(git branch --show-current);
-if [ "$check_branch" == "$linter_branch" ]; then
+if [ "$check_branch" = "$linter_branch" ]; then
     untracked_files=$(git ls-files --others --exclude-standard | grep .github/linters);
     if [ "$untracked_files" != "" ]; then
         # need to manually remove this since the bragi submodule cannot be stashed which may leads to conflicts later when merging in master.

--- a/scripts/update_inside_parent.sh
+++ b/scripts/update_inside_parent.sh
@@ -52,12 +52,11 @@ if [ "$check_branch" == "$linter_branch" ]; then
         git submodule add --force https://github.com/BigVikingGames/Bragi.git .github/linters;
         git submodule update --init .github/linters;
         (
-            cd .github/linters;
+            cd .github/linters || exit 1;
             git fetch;
             git checkout "$submodule_branch";
             git config pull.rebase false;
             git pull;
-            cd ../..;
         )
         .github/linters/scripts/setup-all.sh;
         .github/linters/scripts/setup-local-lint.sh;
@@ -70,7 +69,7 @@ fi;
 # restore your old original branch, index and working tree
 git reset > /dev/null;
 git checkout .;
-git checkout $old_branch;
+git checkout "$old_branch";
 working_tree_stash_num=$(git stash list | grep "working_tree_$now" | sed 's/stash@{\(.*\)}.*/\1/')
 if [ -n "$working_tree_stash_num" ]; then
     git checkout "stash@{$working_tree_stash_num}" .;

--- a/scripts/update_inside_parent.sh
+++ b/scripts/update_inside_parent.sh
@@ -39,9 +39,9 @@
     git checkout -b "$linter_branch";
     git checkout "$linter_branch" --;
     check_branch=$(git branch --show-current);
-    if [ "$untracked_linter" == "$linter_branch" ]; then
+    if [ "$check_branch" == "$linter_branch" ]; then
         untracked_files=$(git ls-files --others --exclude-standard | grep .github/linters);
-        if [ "$untracked_linter" != "" ]; then
+        if [ "$untracked_files" != "" ]; then
             rm -rf .github/linters;
         fi;
         git checkout .;

--- a/scripts/update_inside_parent.sh
+++ b/scripts/update_inside_parent.sh
@@ -59,7 +59,6 @@ if [ "$check_branch" = "$linter_branch" ]; then
             git pull;
         )
         .github/linters/scripts/setup-all.sh;
-        .github/linters/scripts/setup-local-lint.sh;
         git add .github/linters .github/workflows/linter-workflow.yml;
         git commit -n -m "update the bragi linter submodule";
         git push --set-upstream origin "$linter_branch";


### PR DESCRIPTION
Pre-commit check fixes:
- the stashes use time stamps now so restarting interrupted pre-commit checks will never result in lost stashes + data
- the last step of restoring working tree will always point to the correct commit now

Allows a user to easily update all the parent repos after a Bragi has been changed by running the update_all_inside_parent.sh script.
Provides status of thos repo (updated to latest Bragi or not) and also provides links to allow the user to easily open/view the pull requests for the auto generated branches
![Screen Shot 2020-09-25 at 2 26 13 PM](https://user-images.githubusercontent.com/7855531/94302970-1a712f00-ff3b-11ea-9a50-621f55cac87f.png)
.

