### PR TITLE
Allow Spaces for Alignment

### DIFF
--- a/.ecrc
+++ b/.ecrc
@@ -1,0 +1,3 @@
+{
+	"SpacesAftertabs": true
+}

--- a/.ecrc
+++ b/.ecrc
@@ -1,3 +1,3 @@
 {
-	"SpacesAftertabs": true
+	"SpacesAftertabs": false
 }

--- a/.ecrc
+++ b/.ecrc
@@ -1,3 +1,3 @@
 {
-	"SpacesAftertabs": true
+    "SpacesAftertabs": true
 }

--- a/.ecrc
+++ b/.ecrc
@@ -1,3 +1,3 @@
 {
-	"SpacesAftertabs": false
+	"SpacesAftertabs": true
 }


### PR DESCRIPTION
This requires .ecrc files being picked up by super-linter, which they currently are not. We can get this merged, and if my PR gets merged  (not linked because Bragi is public), this should allow spaces to appear after tabs, which will fix a common issue with XML files having aligned attributes (with tabs then spaces, which is whack, but w/e) and spaces for alignment.

super-linter PR (if not merged) is here: https://github.com/github/super-linter/pulls/mshimokura