### PR TITLE
stylelint: Allow Unknown Selectors

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,12 +1,12 @@
 {
-  "extends": "stylelint-config-standard",
-  "rules": {
-    "indentation": "tab",
-    "number-leading-zero": null,
-    "block-no-empty": null,
-    "color-hex-case": null,
-    "color-hex-length": null,
-    "declaration-empty-line-before": null,
-    "selector-type-no-unknown": null
-  }
+	"extends": "stylelint-config-standard",
+	"rules": {
+		"indentation": "tab",
+		"number-leading-zero": null,
+		"block-no-empty": null,
+		"color-hex-case": null,
+		"color-hex-length": null,
+		"declaration-empty-line-before": null,
+		"selector-type-no-unknown": null
+	}
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -6,6 +6,7 @@
     "block-no-empty": null,
     "color-hex-case": null,
     "color-hex-length": null,
-    "declaration-empty-line-before": null
+    "declaration-empty-line-before": null,
+    "selector-type-no-unknown": null
   }
 }


### PR DESCRIPTION
Allow unknown selectors in stylelint, for example "x-button" or any other custom element name.