### PR TITLE
Allow loose equality comparison with null

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -16,4 +16,4 @@ rules:
   # disabled for now, since there's no option for double-indent on continued line
   # indent: [ "error", "tab" ]
   indent: off
-  eqeqeq: [ "error", "always" ]
+  eqeqeq: [ "error", "always", {"null": "ignore"} ] 


### PR DESCRIPTION
Allow `something != null` in typescript. (Checks if something is not null or undefined)

# Warning
Make sure you have updated the Bragi submodule at .github/linters to the latest commit on your new branch before this is merged (and make sure it passes the super linter check).
